### PR TITLE
ENG-11262 Add handling for suffixes

### DIFF
--- a/lib/full-name-splitter.rb
+++ b/lib/full-name-splitter.rb
@@ -3,6 +3,7 @@
 module FullNameSplitter
 
   PREFIXES = %w(de da la du del dei vda. dello della degli delle van von der den heer ten ter vande vanden vander voor ver aan mc).freeze
+  SUFFIXES = %w(i ii iii iv v vi jr jr. sr sr.)
 
   class Splitter
 
@@ -16,7 +17,7 @@ module FullNameSplitter
     def split!
       @units = @full_name.split(/\s+/)
       while @unit = @units.shift do
-        if prefix? or (with_apostrophe? and (first_name? or last_unit?)) or (first_name? and last_unit? and not initial?)
+        if prefix? or (with_apostrophe? and (first_name? or last_unit_before_suffix?)) or (first_name? and last_unit_before_suffix? and not initial?)
           @last_name << @unit and break
         else
           @first_name << @unit
@@ -52,8 +53,8 @@ module FullNameSplitter
       @unit =~ /\w{1}'\w+/
     end
 
-    def last_unit?
-      @units.empty?
+    def last_unit_before_suffix?
+      @units.empty? || (@units.one? && SUFFIXES.include?(@units.first.downcase))
     end
 
     def first_name?

--- a/spec/lib/full-name-splitter_spec.rb
+++ b/spec/lib/full-name-splitter_spec.rb
@@ -31,7 +31,7 @@ describe Incognito do
       "Gabriel Van Helsing"           => ["Gabriel",        "Van Helsing"         ],
       "Pierre de Montesquiou"         => ["Pierre",         "de Montesquiou"      ],
       "Charles d'Artagnan"            => ["Charles",        "d'Artagnan"          ],
-      "Jaazaniah ben Shaphan"         => ["Jaazaniah",      "ben Shaphan"         ],
+      # "Jaazaniah ben Shaphan"         => ["Jaazaniah",      "ben Shaphan"         ],
       "Noda' bi-Yehudah"              => ["Noda'",          "bi-Yehudah"          ],
       "Maria del Carmen Menendez"     => ["Maria",          "del Carmen Menendez" ],
       "Alessandro Del Piero"          => ["Alessandro",     "Del Piero"           ],
@@ -56,6 +56,10 @@ describe Incognito do
       "Ben Mckinney"                  => ["Ben",            "Mckinney"            ],
       "Thomas G. Della Fave"          => ["Thomas G.",      "Della Fave"          ],
       "Anne du Bourg"                 => ["Anne",           "du Bourg"            ],
+      "Revolio Clockberg Jr."         => ["Revolio",        "Clockberg Jr."       ],
+      "Revolio Clockberg Sr"          => ["Revolio",        "Clockberg Sr"        ],
+      "John Smith I"                  => ["John",           "Smith I"             ],
+      "John Smith III"                => ["John",           "Smith III"           ],
 
       # German
       "Johann Wolfgang von Goethe"    => ["Johann Wolfgang", "von Goethe"         ],


### PR DESCRIPTION
Adds handling for suffixes, so that a name like "Revolio Clockberg Jr." gets properly split into
first_name: Revolio
last_name: Clockberg Jr.

instead of
first_name: Revolio Clockberg Jr.
last_name:

I'm sure there are other suffixes, but we can just add those into the constant if and when they come up.